### PR TITLE
MNT: move component name away from method name

### DIFF
--- a/src/cditools/eiger_async.py
+++ b/src/cditools/eiger_async.py
@@ -188,7 +188,7 @@ class EigerDriverIO(ADBaseIO, NDFileIO):
     photon_energy: A[SignalRW[float], PvSuffix.rbv("PhotonEnergy")]
 
     # Trigger Setup
-    trigger: A[SignalRW[float], PvSuffix("Trigger")]
+    trigger_: A[SignalRW[float], PvSuffix("Trigger")]
     trigger_exposure: A[SignalRW[float], PvSuffix.rbv("TriggerExposure")]
     num_triggers: A[SignalRW[int], PvSuffix.rbv("NumTriggers")]
     manual_trigger: A[SignalRW[bool], PvSuffix.rbv("ManualTrigger")]
@@ -509,7 +509,7 @@ class EigerAcquireLogic(DetectorAcquireLogic):
 
     async def start_acquiring(self):
         self._rolling_image_counter = await self.driver.num_images_counter.get_value()
-        ret = await self.driver.trigger.set(1)
+        ret = await self.driver.trigger_.set(1)
         return ret
 
     async def wait_for_idle(self):

--- a/tests/test_eiger_async.py
+++ b/tests/test_eiger_async.py
@@ -543,7 +543,7 @@ async def test_eiger_detector(mock_eiger_detector: EigerDetector) -> None:
             mock_eiger_detector.driver.num_images_counter, num_images_counter + 1
         )
 
-    callback_on_mock_put(mock_eiger_detector.driver.trigger, _simulate_one_trigger)
+    callback_on_mock_put(mock_eiger_detector.driver.trigger_, _simulate_one_trigger)
 
     # Standalone methods
     await mock_eiger_detector.prepare(
@@ -638,7 +638,7 @@ async def test_eiger_detector_with_RE(
 
     tiled_writer = TiledWriter(tiled_client)
     RE.subscribe(tiled_writer)
-    callback_on_mock_put(mock_eiger_detector.driver.trigger, _write_file)
+    callback_on_mock_put(mock_eiger_detector.driver.trigger_, _write_file)
 
     set_mock_value(mock_eiger_detector.data_logic.fileio.sequence_id, 0)
     set_mock_value(mock_eiger_detector.driver.num_images, 1)


### PR DESCRIPTION
Check was added in ophyd-async 0.19.4 (which also includes the fix we need for merlin)

Tested at beamline